### PR TITLE
chore: release v0.2.1

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -5,6 +5,8 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   push:
+    branches:
+      - main
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1 (2023-05-15)
+
+- Removed `#[must_use]` attribute from `collect_codepoints()`, to allow for use cases for skipping certain codepoints (e.g skipping ASCII whitespace)
+
 ## 0.2.0 (2023-04-30)
 
 - Added 3 new traits:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whatwg-infra"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
 	"Samantha Nguyen, <contact@samanthanguyen.me>",
 ]
@@ -19,8 +19,12 @@ exclude = [
 	".devcontainer",
 	".github",
 	".vscode",
+	".idea",
 	"deny.toml",
 	".commitlintrc.json",
 	"package.json",
 	"package-lock.json",
+	"fuzz",
+	"book",
+	"benches",
 ]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 [![Security audit](https://github.com/acmuta-research/whatwg-infra-rs/actions/workflows/security-audit.yml/badge.svg)](https://github.com/acmuta-research/whatwg-infra-rs/actions/workflows/security-audit.yml)
 [![codecov](https://codecov.io/gh/acmuta-research/whatwg-infra-rs/branch/main/graph/badge.svg?token=6ZSIWAQTHU)](https://codecov.io/gh/acmuta-research/whatwg-infra-rs)
 
-A tiny Rust crate that implements part of the WHATWG Infra Standard.
+A tiny Rust crate that implements parts of the WHATWG Infra Standard. Specifically, it implements the following:
+
+- [4.5. Code points](https://infra.spec.whatwg.org/#code-points)
+- [4.6. Strings](https://infra.spec.whatwg.org/#strings)
+
+It exposes a small set of primitives that are useful for parsing text into machine-readable data.
 
 ## Install
 

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -175,7 +175,6 @@ pub fn trim_collapse_ascii_whitespace(s: &str) -> String {
 /// assert_eq!(collected, String::from("test"));
 /// assert_eq!(position, 4);
 /// ```
-#[must_use]
 pub fn collect_codepoints<P>(s: &str, position: &mut usize, mut predicate: P) -> String
 where
 	P: FnMut(char) -> bool,


### PR DESCRIPTION
 - remove `#[must_use]` attribute from `collect_codepoints()` so it's more ergonomic in the case where the user might want to skip certain characters (e.g ASCII whitespace)
 - update README.md to include more specific details on what parts are implemented
 - sync Cargo.toml with template